### PR TITLE
removed a content delivery network from tracking.txt

### DIFF
--- a/tracking.txt
+++ b/tracking.txt
@@ -256,8 +256,7 @@ bingapis.com
 msedge.net 
 assets.msn.com 
 scorecardresearch.com edge.microsoft.com 
-data.msn.com 
-cdn.oaistatic.com
+data.msn.com
 megabrain.co
 cloudflareinsight.com
 intercom.com


### PR DESCRIPTION
removed cdn.oaistatic.com from the list due to broken site ( see [discussion 33](https://github.com/Moineau54/blocklist/discussions/33) for explenation)